### PR TITLE
Implement running_channel_count and update stats

### DIFF
--- a/services/comsrv/examples/protocol_factory_usage.rs
+++ b/services/comsrv/examples/protocol_factory_usage.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
     
     // Example 4: Get channel statistics
     println!("\n=== Example 4: Channel Statistics ===");
-    let stats = factory.get_channel_stats();
+    let stats = factory.get_channel_stats().await;
     println!("Total channels: {}", stats.total_channels);
     println!("Protocol distribution: {:?}", stats.protocol_counts);
     

--- a/services/comsrv/src/main.rs
+++ b/services/comsrv/src/main.rs
@@ -201,7 +201,7 @@ async fn start_communication_service(
         // Log but don't fail - some channels might have started successfully
     }
     
-    let stats = factory_guard.get_channel_stats();
+    let stats = factory_guard.get_channel_stats().await;
     info!("Communication service started with {} channels (Protocol distribution: {:?})", 
           stats.total_channels, stats.protocol_counts);
     drop(factory_guard);
@@ -326,7 +326,7 @@ fn start_cleanup_task(factory: Arc<RwLock<ProtocolFactory>>) -> tokio::task::Joi
             factory_guard.cleanup_channels(std::time::Duration::from_secs(3600)).await;
             
             // Log statistics
-            let stats = factory_guard.get_channel_stats();
+            let stats = factory_guard.get_channel_stats().await;
             info!("Channel stats: total={}, running={}", 
                   stats.total_channels, stats.running_channels);
             drop(factory_guard);

--- a/services/comsrv/tests/modbus_integration_tests.rs
+++ b/services/comsrv/tests/modbus_integration_tests.rs
@@ -297,7 +297,7 @@ async fn test_multiple_channels() {
     assert!(created_count >= 1, "At least one channel should be created successfully");
     
     // Test channel statistics
-    let stats = factory.get_channel_stats();
+    let stats = factory.get_channel_stats().await;
     assert_eq!(stats.total_channels, created_count);
 }
 


### PR DESCRIPTION
## Summary
- count running channels using new `running_channel_count` async method
- update `get_channel_stats` to be async and use the new method
- adjust main service and example to await the updated API
- expand tests to verify running channel count

## Testing
- `cargo test --manifest-path services/comsrv/Cargo.toml --no-run` *(fails: failed to get `voltage_modbus`)*

------
https://chatgpt.com/codex/tasks/task_e_68430c4177988325b69ec80765512746