### PR TITLE
Expose communication service helpers

### DIFF
--- a/services/comsrv/src/lib.rs
+++ b/services/comsrv/src/lib.rs
@@ -155,6 +155,7 @@
 pub mod core;
 pub mod utils;
 pub mod api;
+mod service_impl;
 
 /// Service entry point and lifecycle management
 /// 
@@ -225,6 +226,7 @@ pub mod service {
     use tokio::sync::RwLock;
     use crate::{ConfigManager, ProtocolFactory};
     use crate::utils::Result;
+    use crate::service_impl as impls;
     
     /// Start the communication service with optimized performance and monitoring
     /// 
@@ -295,13 +297,13 @@ pub mod service {
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// This function simply forwards to [`crate::service_impl::start_communication_service`].
     pub async fn start_communication_service(
-        _config_manager: Arc<ConfigManager>,
-        _factory: Arc<RwLock<ProtocolFactory>>
+        config_manager: Arc<ConfigManager>,
+        factory: Arc<RwLock<ProtocolFactory>>,
     ) -> Result<()> {
-        // This is a placeholder for documentation purposes
-        // The actual implementation is in main.rs
-        todo!("This function is implemented in the binary")
+        impls::start_communication_service(config_manager, factory).await
     }
     
     /// Handle graceful shutdown of the communication service
@@ -363,14 +365,14 @@ pub mod service {
     ///         tokio::signal::ctrl_c().await.unwrap();
     ///         shutdown_handler(factory_clone).await;
     ///     });
-    ///     
+    ///
     ///     // Main service loop...
     /// }
     /// ```
-    pub async fn shutdown_handler(_factory: Arc<RwLock<ProtocolFactory>>) {
-        // This is a placeholder for documentation purposes
-        // The actual implementation is in main.rs
-        todo!("This function is implemented in the binary")
+    ///
+    /// This function simply forwards to [`crate::service_impl::shutdown_handler`].
+    pub async fn shutdown_handler(factory: Arc<RwLock<ProtocolFactory>>) {
+        impls::shutdown_handler(factory).await;
     }
     
     /// Start the periodic cleanup task for resource management
@@ -446,12 +448,10 @@ pub mod service {
     ///     }
     /// }
     /// ```
-    pub fn start_cleanup_task(_factory: Arc<RwLock<ProtocolFactory>>) -> tokio::task::JoinHandle<()> {
-        // This is a placeholder for documentation purposes
-        // The actual implementation is in main.rs
-        tokio::spawn(async {
-            todo!("This function is implemented in the binary")
-        })
+    ///
+    /// This function simply forwards to [`crate::service_impl::start_cleanup_task`].
+    pub fn start_cleanup_task(factory: Arc<RwLock<ProtocolFactory>>) -> tokio::task::JoinHandle<()> {
+        impls::start_cleanup_task(factory)
     }
 }
 

--- a/services/comsrv/src/service_impl.rs
+++ b/services/comsrv/src/service_impl.rs
@@ -1,0 +1,140 @@
+// Service implementation shared between library and binary
+// Contains concrete functions for starting, shutting down, and cleaning up the
+// communication service.
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{info, warn, error};
+
+use crate::core::config::ConfigManager;
+use crate::core::protocols::common::ProtocolFactory;
+use crate::core::metrics::get_metrics;
+use crate::utils::error::Result;
+
+/// Start the communication service with optimized performance and monitoring.
+pub async fn start_communication_service(
+    config_manager: Arc<ConfigManager>,
+    factory: Arc<RwLock<ProtocolFactory>>,
+) -> Result<()> {
+    // Get channel configurations
+    let configs = config_manager.get_channels().clone();
+
+    if configs.is_empty() {
+        warn!("No channels configured");
+        return Ok(());
+    }
+
+    info!("Creating {} channels...", configs.len());
+
+    // Create channels with improved error handling and metrics
+    let mut successful_channels = 0;
+    let mut failed_channels = 0;
+
+    for channel_config in configs {
+        info!("Creating channel: {} - {}", channel_config.id, channel_config.name);
+
+        let factory_guard = factory.write().await;
+        match factory_guard.create_channel(channel_config.clone()) {
+            Ok(_) => {
+                info!("Channel created successfully: {}", channel_config.id);
+                successful_channels += 1;
+
+                // Record metrics if available
+                if let Some(metrics) = get_metrics() {
+                    metrics.update_channel_status(
+                        &channel_config.id.to_string(),
+                        false, // Not connected yet
+                        &config_manager.get_service_name(),
+                    );
+                }
+            }
+            Err(e) => {
+                error!("Failed to create channel {}: {}", channel_config.id, e);
+                failed_channels += 1;
+
+                // Record error metrics if available
+                if let Some(metrics) = get_metrics() {
+                    metrics.record_channel_error(
+                        &channel_config.id.to_string(),
+                        "creation_failed",
+                        &config_manager.get_service_name(),
+                    );
+                }
+
+                // Continue with other channels instead of failing completely
+                continue;
+            }
+        }
+        drop(factory_guard); // Release the lock for each iteration
+    }
+
+    info!(
+        "Channel creation completed: {} successful, {} failed",
+        successful_channels, failed_channels
+    );
+
+    // Start all channels with improved performance
+    let factory_guard = factory.read().await;
+    if let Err(e) = factory_guard.start_all_channels().await {
+        error!("Failed to start some channels: {}", e);
+        // Log but don't fail - some channels might have started successfully
+    }
+
+    let stats = factory_guard.get_channel_stats();
+    info!(
+        "Communication service started with {} channels (Protocol distribution: {:?})",
+        stats.total_channels, stats.protocol_counts
+    );
+    drop(factory_guard);
+
+    // Update service metrics
+    if let Some(metrics) = get_metrics() {
+        metrics.update_service_status(true);
+    }
+
+    Ok(())
+}
+
+/// Handle graceful shutdown of the communication service.
+pub async fn shutdown_handler(factory: Arc<RwLock<ProtocolFactory>>) {
+    info!("Starting graceful shutdown...");
+
+    let factory_guard = factory.read().await;
+    if let Err(e) = factory_guard.stop_all_channels().await {
+        error!("Error during channel shutdown: {}", e);
+    }
+    drop(factory_guard);
+
+    // Update service metrics
+    if let Some(metrics) = get_metrics() {
+        metrics.update_service_status(false);
+    }
+
+    info!("All channels stopped");
+}
+
+/// Start the periodic cleanup task for resource management.
+pub fn start_cleanup_task(
+    factory: Arc<RwLock<ProtocolFactory>>, 
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(300)); // 5 minutes
+
+        loop {
+            interval.tick().await;
+
+            // Clean up idle channels (1 hour idle time)
+            let factory_guard = factory.read().await;
+            factory_guard.cleanup_channels(std::time::Duration::from_secs(3600)).await;
+
+            // Log statistics
+            let stats = factory_guard.get_channel_stats();
+            info!(
+                "Channel stats: total={}, running={}",
+                stats.total_channels, stats.running_channels
+            );
+            drop(factory_guard);
+        }
+    })
+}
+


### PR DESCRIPTION
## Summary
- move communication service helper functions into a shared `service_impl` module
- expose thin wrappers in the library that delegate to the shared code
- update binary to use the shared implementations

## Testing
- `cargo check` *(fails: failed to load voltage_modbus)*
- `cargo test --no-run` *(fails: failed to load voltage_modbus)*

------
https://chatgpt.com/codex/tasks/task_e_68430c3fc7a8832590026c527e2afa5f