### PR TITLE
Fix get_channel_stats await

### DIFF
--- a/services/comsrv/src/service_impl.rs
+++ b/services/comsrv/src/service_impl.rs
@@ -80,7 +80,7 @@ pub async fn start_communication_service(
         // Log but don't fail - some channels might have started successfully
     }
 
-    let stats = factory_guard.get_channel_stats();
+    let stats = factory_guard.get_channel_stats().await;
     info!(
         "Communication service started with {} channels (Protocol distribution: {:?})",
         stats.total_channels, stats.protocol_counts
@@ -128,7 +128,7 @@ pub fn start_cleanup_task(
             factory_guard.cleanup_channels(std::time::Duration::from_secs(3600)).await;
 
             // Log statistics
-            let stats = factory_guard.get_channel_stats();
+            let stats = factory_guard.get_channel_stats().await;
             info!(
                 "Channel stats: total={}, running={}",
                 stats.total_channels, stats.running_channels


### PR DESCRIPTION
## Summary
- await `get_channel_stats` in communication service implementation

## Testing
- `cargo check` *(fails: could not get `voltage_modbus` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6843170de7b88325805ba18aa3e0e41d