### PR TITLE
Update README docs for comsrv

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## 服务组件
 
-- **Comsrv**: 通信服务，负责与设备通信，采集实时数据
+ - **Comsrv**: 通信服务，负责与设备通信并采集实时数据，支持 Modbus TCP/RTU、CAN 等协议
 - **Hissrv**: 历史数据服务，负责将实时数据存储到时序数据库
 - **modsrv**: 模型服务，负责执行实时模型计算和控制策略
 - **netsrv**: 网络服务，负责将数据通过多种协议上送到外部系统
@@ -33,7 +33,7 @@
 
 ## 技术栈
 
-- **Comsrv**: C++
+ - **Comsrv**: Rust
 - **Hissrv**: Rust
 - **modsrv**: Rust
 - **netsrv**: Rust
@@ -48,8 +48,8 @@
 ### 前提条件
 
 - Docker 和 Docker Compose
-- Rust 1.67 或更高版本 (开发时需要)
-- C++ 编译器 (开发 Comsrv 时需要)
+- Rust 1.67 或更高版本 (开发 comsrv 等服务需要)
+- Python 3 (测试和模拟工具需要)
 - Node.js 16 或更高版本 (开发前端和 API 时需要)
 
 ### 使用 Docker Compose 启动

--- a/services/comsrv/README.md
+++ b/services/comsrv/README.md
@@ -1,6 +1,14 @@
 # Communication Service (comsrv)
 
-通信服务模块为EMS系统提供了统一的工业通信协议支持。该架构设计为可扩展的、异步的、高性能的通信框架。
+通信服务模块为 EMS 系统提供统一的工业协议接入。核心采用 Rust + Tokio，实现高并发的异步通信。
+
+## 功能特色
+
+- 支持 Modbus TCP、Modbus RTU 和 CAN 总线
+- 可扩展的协议工厂机制，便于添加新协议
+- 基于 Warp 的 REST API，用于通道和点表管理
+- 内置 Prometheus 指标，方便监控
+- 配置与点表采用 YAML/CSV 格式
 
 ## 🏗️ 架构概览
 


### PR DESCRIPTION
## Summary
- document comsrv features in main README
- fix comsrv language mention (Rust) and prerequisites
- add feature overview to `services/comsrv` README

## Testing
- `cargo test --quiet` *(fails: failed to get `voltage_modbus` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_684316f340188325a2e9df4378a9e91d