### PR TITLE
Fix connection pool permits and await stats

### DIFF
--- a/services/comsrv/src/main.rs
+++ b/services/comsrv/src/main.rs
@@ -207,7 +207,7 @@ async fn start_communication_service(
         // Log but don't fail - some channels might have started successfully
     }
     
-    let stats = factory_guard.get_channel_stats();
+    let stats = factory_guard.get_channel_stats().await;
     info!("Communication service started with {} channels (Protocol distribution: {:?})", 
           stats.total_channels, stats.protocol_counts);
     drop(factory_guard);
@@ -332,7 +332,7 @@ fn start_cleanup_task(factory: Arc<RwLock<ProtocolFactory>>) -> tokio::task::Joi
             factory_guard.cleanup_channels(std::time::Duration::from_secs(3600)).await;
             
             // Log statistics
-            let stats = factory_guard.get_channel_stats();
+            let stats = factory_guard.get_channel_stats().await;
             info!("Channel stats: total={}, running={}", 
                   stats.total_channels, stats.running_channels);
             drop(factory_guard);
@@ -531,6 +531,9 @@ async fn main() -> Result<()> {
     
     // Perform graceful shutdown
     shutdown_handler(factory).await;
+    // Stop background cleanup task
+    cleanup_handle.abort();
+    let _ = cleanup_handle.await;
     info!("Communication service shutdown completed");
     
     Ok(())


### PR DESCRIPTION
## Summary
- await async `get_channel_stats` in main
- store permit in `PooledConnectionGuard` and return cleanup handle for connection pools
- abort cleanup task on shutdown
- adjust connection pool tests for new permit logic

## Testing
- `cargo check --manifest-path services/comsrv/Cargo.toml --offline` *(fails: failed to get `voltage_modbus` as a dependency)*
- `cargo test --manifest-path services/comsrv/Cargo.toml --offline` *(fails: failed to get `voltage_modbus` as a dependency)*
- `cargo fmt --all` *(fails: component rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68430b15c4dc83258fc10b4040e64962