### PR TITLE
Add channel monitoring utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ python generate_config.py --output ./my_config --modbus 3 --opcua 2 --points 30
 - `--opcua` - OPC UA通道数量，默认为2
 - `--points` - 每个通道的点位数量，默认为20
 
+### 通道监控脚本 (channel_monitor.py)
+
+该脚本周期性地请求 comsrv 的 `/api/v1/channels` 接口，并在终端中展示通道状态。
+
+```bash
+# 直接运行
+python tools/channel_monitor.py --interactive
+
+# 或使用封装脚本
+./monitor.sh
+```
+
 ## 典型测试流程
 
 1. 使用配置生成工具生成测试配置文件：

--- a/monitor.sh
+++ b/monitor.sh
@@ -28,4 +28,4 @@ fi
 # 启动交互式监控
 echo "🚀 启动交互式监控界面..."
 echo ""
-$PYTHON_CMD tools/channel_monitor.py -i 
+$PYTHON_CMD tools/channel_monitor.py --interactive

--- a/tools/channel_monitor.py
+++ b/tools/channel_monitor.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Simple comsrv channel monitoring tool."""
+
+import argparse
+import time
+from datetime import datetime
+from typing import List
+
+import requests
+
+
+def fetch_channel_status(base_url: str):
+    url = f"{base_url.rstrip('/')}/api/v1/channels"
+    resp = requests.get(url, timeout=5)
+    resp.raise_for_status()
+    data = resp.json()
+    if isinstance(data, dict) and 'data' in data:
+        return data['data']
+    return data
+
+
+def print_channels(channels: List[dict]):
+    print(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+    header = f"{'ID':<5} {'NAME':<15} {'PROTOCOL':<10} {'STATUS':<8} LAST_ERROR"
+    print(header)
+    print("-" * len(header))
+    for ch in channels:
+        status = 'ON' if ch.get('connected') else 'OFF'
+        print(f"{ch.get('id', ''):<5} {ch.get('name', ''):<15} {ch.get('protocol', ''):<10} {status:<8} {ch.get('last_error', '')}")
+    print()
+
+
+def interactive_loop(base_url: str, interval: float):
+    try:
+        while True:
+            channels = fetch_channel_status(base_url)
+            print_channels(channels)
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        print("Exiting...")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Monitor comsrv channel status")
+    parser.add_argument('-u', '--url', default='http://localhost:3001', help='Base URL of comsrv service')
+    parser.add_argument('-i', '--interactive', action='store_true', help='Run in interactive mode')
+    parser.add_argument('--interval', type=float, default=2.0, help='Refresh interval in seconds')
+    args = parser.parse_args()
+
+    if args.interactive:
+        interactive_loop(args.url, args.interval)
+    else:
+        channels = fetch_channel_status(args.url)
+        print_channels(channels)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `tools/channel_monitor.py` for viewing comsrv channel status
- call the tool from `monitor.sh`
- document monitor usage in README

## Testing
- `python3 -m py_compile tools/channel_monitor.py`
- `python3 tools/channel_monitor.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*
- `cargo check --manifest-path services/comsrv/Cargo.toml` *(fails: failed to load voltage_modbus dependency)*

------
https://chatgpt.com/codex/tasks/task_e_684466ee9efc832596c2e33a17a22051