### PR TITLE
Use Lazy RwLock for parser registry

### DIFF
--- a/services/comsrv/src/core/protocols/mod.rs
+++ b/services/comsrv/src/core/protocols/mod.rs
@@ -13,16 +13,19 @@ use crate::core::protocols::iec60870::Iec60870PacketParser;
 /// Registers all available protocol parsers with the global registry.
 /// This function should be called during application startup.
 pub fn init_protocol_parsers() {
-    let registry = get_global_parser_registry();
-    
+    let mut registry = get_global_parser_registry().write();
+
     // Register Modbus parser
     registry.register_parser(ModbusPacketParser::new());
-    
+
     // Register CAN parser
     registry.register_parser(CanPacketParser::new());
 
     // Register IEC60870 parser
     registry.register_parser(Iec60870PacketParser::new());
-    
-    tracing::info!("Protocol parsers initialized: {:?}", registry.registered_protocols());
-} 
+
+    tracing::info!(
+        "Protocol parsers initialized: {:?}",
+        registry.registered_protocols()
+    );
+}

--- a/services/comsrv/tests/protocol_parser_registration.rs
+++ b/services/comsrv/tests/protocol_parser_registration.rs
@@ -4,6 +4,7 @@ use comsrv::core::protocols::{init_protocol_parsers, common::combase::get_global
 fn test_protocol_parser_registration() {
     init_protocol_parsers();
     let registry = get_global_parser_registry();
+    let registry = registry.read();
     let protocols = registry.registered_protocols();
     assert!(protocols.contains(&"Modbus".to_string()));
     assert!(protocols.contains(&"CAN".to_string()));


### PR DESCRIPTION
## Summary
- use `once_cell::sync::Lazy` and `parking_lot::RwLock` for the global parser registry
- adapt parser initialization and tests to work with the new locking API

## Testing
- `cargo check` *(fails: failed to load manifest for dependency `voltage_modbus`)*
- `cargo test` *(fails: failed to load manifest for dependency `voltage_modbus`)*


------
https://chatgpt.com/codex/tasks/task_e_6845867907f483258faa28dd49a38335