### PR TITLE
Remove unused imports

### DIFF
--- a/services/comsrv/src/api/mod.rs
+++ b/services/comsrv/src/api/mod.rs
@@ -2,7 +2,4 @@ pub mod routes;
 pub mod handlers;
 pub mod models;
 
-use std::sync::Arc;
-use warp::Filter;
-use crate::core::config::ConfigManager;
-use crate::core::protocols::common::ProtocolFactory;
+// Future helper functions can be added here as needed.


### PR DESCRIPTION
## Summary
- clean up unused imports in `api/mod.rs`

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo test --manifest-path services/comsrv/Cargo.toml --locked` *(fails: missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6845867dd58c83258910f8aaf98a85c1