### PR TITLE
fix EOF newline in comsrv

### DIFF
--- a/services/comsrv/src/lib.rs
+++ b/services/comsrv/src/lib.rs
@@ -459,4 +459,4 @@ pub mod service {
 pub use utils::{ComSrvError, Result};
 pub use core::config::config_manager::ConfigManager;
 pub use core::protocols::common::ProtocolFactory;
-pub use core::protocols::common::combase::{ComBase, ComBaseImpl, ChannelStatus, PointData}; 
+pub use core::protocols::common::combase::{ComBase, ComBaseImpl, ChannelStatus, PointData};


### PR DESCRIPTION
## Summary
- ensure `services/comsrv/src/lib.rs` ends with a newline

## Testing
- `cargo fmt` *(fails: rustfmt component missing)*
- `cargo test --manifest-path services/comsrv/Cargo.toml --no-run` *(fails: could not find dependency `voltage_modbus`)*

------
https://chatgpt.com/codex/tasks/task_e_68458686df3c832592717a8d23d4ad09