### PR TITLE
Remove unused logger import

### DIFF
--- a/services/comsrv/src/utils/logger.rs
+++ b/services/comsrv/src/utils/logger.rs
@@ -8,7 +8,6 @@ use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::fmt;
 use tracing_subscriber::EnvFilter;
 
-use crate::core::config::config_manager::ChannelConfig;
 use crate::core::protocols::common::combase::{parse_protocol_packet, PacketParseResult};
 use crate::utils::error::{ComSrvError, Result};
 


### PR DESCRIPTION
## Summary
- clean up logger by removing unused `ChannelConfig` import

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo build` *(fails: could not find dependency `voltage_modbus`)*

------
https://chatgpt.com/codex/tasks/task_e_6845868442cc8325ae6d178bc953d6f0