### PR TITLE
Add AWS IoT TLS support

### DIFF
--- a/services/netsrv/Cargo.toml
+++ b/services/netsrv/Cargo.toml
@@ -47,4 +47,7 @@ aws-types = { version = "0.54.1", optional = true }
 # Optional cloud platform support
 [features]
 default = []
-aws-iot = ["aws-sdk-iotdataplane", "aws-config", "aws-types"] 
+aws-iot = ["aws-sdk-iotdataplane", "aws-config", "aws-types"]
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
## Summary
- enable TLS transport for cloud MQTT configs
- use connection timeout for cloud clients
- add certificate-based test
- add `tempfile` dev dependency

## Testing
- `cargo test --manifest-path services/netsrv/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_685c98a5792483258fe6c03608273f30