### PR TITLE
chore(docs): purge remaining @tag JavaDoc comments in modsrv/comsrv helpers

### DIFF
--- a/services/comsrv/tests/test_service_integration.rs
+++ b/services/comsrv/tests/test_service_integration.rs
@@ -161,8 +161,11 @@ logging:
         Ok(())
     }
 
-    /// Initialize test database using Monarch
-    /// @param db_dir - Directory where database will be created (not the file path)
+    /// Initialize test database using Monarch.
+    ///
+    /// `db_dir` is the **directory** that will contain the database files,
+    /// not the path to a `.db` file itself — Monarch creates the file
+    /// inside it.
     async fn setup_test_database(&self, db_dir: &str) -> Result<()> {
         // Create database directory
         std::fs::create_dir_all(db_dir)?;

--- a/services/modsrv/src/bootstrap.rs
+++ b/services/modsrv/src/bootstrap.rs
@@ -565,10 +565,6 @@ pub async fn create_app_state(service_info: &ServiceInfo) -> Result<Arc<AppState
 /// (inst:name:index Hash) for O(1) instance name lookups. This is needed for:
 /// - Migration from old deployment without the index
 /// - Recovery after index corruption
-///
-/// @input pool: SQLite connection pool
-/// @input rtdb: Redis RTDB instance
-/// @output `Result<usize>` - Number of instances indexed
 async fn rebuild_instance_name_index<R: voltage_rtdb::Rtdb>(
     pool: &SqlitePool,
     rtdb: &R,

--- a/services/modsrv/src/instance_manager.rs
+++ b/services/modsrv/src/instance_manager.rs
@@ -236,13 +236,12 @@ impl<R: Rtdb + 'static> InstanceManager<R> {
         self.name_cache.remove(instance_name);
     }
 
-    /// Create a new instance based on a product template
+    /// Create a new instance based on a product template.
     ///
-    /// @input req: CreateInstanceRequest - Instance configuration
-    /// @output `Result<Instance>` - Created instance with all point routings
-    /// @throws anyhow::Error - Instance exists, product not found, database error
-    /// @side-effects Creates instance in SQLite, initializes Redis keys
-    /// @transaction Full creation is atomic
+    /// Writes the instance row to SQLite and initializes the corresponding
+    /// Redis keys (`inst:{id}:M`, `inst:{id}:A`, name index). The whole
+    /// creation is wrapped in a transaction so either everything lands or
+    /// nothing does — partial state never persists.
     pub async fn create_instance(
         &self,
         req: CreateInstanceRequest,

--- a/services/modsrv/src/product_loader.rs
+++ b/services/modsrv/src/product_loader.rs
@@ -149,10 +149,6 @@ impl ProductLoader {
     // ============ Product Query Methods (from compile-time data) ============
 
     /// Get a complete product with nested structure
-    ///
-    /// @input product_name: &str - Product identifier to retrieve
-    /// @output `Result<Product>` - Product with all point definitions
-    /// @throws anyhow::Error - Product not found
     pub fn get_product(&self, product_name: &str) -> Result<Product> {
         if let Some(lib) = &self.library {
             let builtin = lib

--- a/services/modsrv/src/redis_state.rs
+++ b/services/modsrv/src/redis_state.rs
@@ -375,12 +375,6 @@ where
 ///
 /// Updates the reverse index (inst:name:index) and the name key (inst:{id}:name).
 /// Routing keys (route:c2m, route:m2c) use instance_id, so they don't need updates.
-///
-/// @input redis: &R - Redis client
-/// @input instance_id: u32 - Instance ID
-/// @input old_name: &str - Old instance name
-/// @input new_name: &str - New instance name
-/// @output Result<()> - Success or error
 pub async fn rename_instance_in_redis<R>(
     redis: &R,
     instance_id: u32,


### PR DESCRIPTION
Follow-up to #90. After that PR cleared every OpenAPI doc block of
`@route/@input/@output/@status/@side-effects` JavaDoc tags, 17 lines of
the same style still lived on five non-HTTP helper functions:

  - `services/modsrv/src/product_loader.rs` — `get_product`
  - `services/modsrv/src/bootstrap.rs` — `rebuild_instance_name_index`
  - `services/modsrv/src/instance_manager.rs` — `create_instance`
  - `services/modsrv/src/redis_state.rs` — `rename_instance_in_redis`
  - `services/comsrv/tests/test_service_integration.rs` —
    `setup_test_database`

utoipa doesn't see these (no `#[utoipa::path]` decoration), so Swagger
UI was already unaffected. But IDE hover tooltips read them, and they
were duplicating information already present in the function signature
(e.g. `@input pool: SQLite connection pool` next to `pool: &SqlitePool`).

For three of the five (`get_product`, `rebuild_instance_name_index`,
`rename_instance_in_redis`) the existing summary line plus narrative
already covered the function adequately — just stripped the tag block.

Two needed actual rewrites because the tags carried semantics, not
duplication:

  - `create_instance` had `@side-effects` describing the
    SQLite-and-Redis dual write and `@transaction` documenting
    atomicity. Lifted both into a prose paragraph.
  - `setup_test_database` had `@param db_dir - Directory where database
    will be created (not the file path)` — a real gotcha. Hoisted into
    a prose paragraph with the word "directory" bolded so callers can't
    miss it.

Verification: `grep -rn '/// @[a-zA-Z]' services/ libs/` returns zero
across the workspace.

Build + clippy clean on touched crates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPKzV8arbMdDrvvDzDfzGF)_