### PR TITLE
feat(shm): Step 3 PR 1 — per-generation file mechanism (foundation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5844,6 +5844,7 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
  "uuid",
+ "zerocopy",
  "zeroize",
 ]
 

--- a/libs/voltage-rtdb-shm/src/core/config.rs
+++ b/libs/voltage-rtdb-shm/src/core/config.rs
@@ -7,6 +7,8 @@
 
 use std::path::{Path, PathBuf};
 
+use anyhow::{Context, Result};
+
 /// Magic number for validation: "VOLTAGE_" in ASCII.
 pub const SHARED_MAGIC: u64 = 0x564F4C544147455F;
 
@@ -63,4 +65,121 @@ pub fn timestamp_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// Compute the path for a per-generation SHM file given the canonical
+/// "current" path and a generation number.
+///
+/// Convention: a base path of `/dev/shm/voltage-rtdb.shm` with generation
+/// 42 yields `/dev/shm/voltage-rtdb-42.shm`. The base path itself
+/// continues to refer to the "current" generation — atomic swaps land a
+/// freshly-created per-generation file at the base path via
+/// `rename(2)`, preserving the open file inode for any reader that
+/// already mmap'd the previous generation.
+///
+/// If the base path has no extension, the generation suffix is appended
+/// directly (no `.shm`). Multiple-extension paths (`foo.shm.bak`) get
+/// the generation injected before the final extension.
+pub fn generation_file_path(base: &Path, generation: u64) -> PathBuf {
+    let parent = base.parent();
+    let file_name = base.file_name().and_then(|s| s.to_str()).unwrap_or("");
+    let new_name = match file_name.rsplit_once('.') {
+        Some((stem, ext)) if !stem.is_empty() => format!("{stem}-{generation}.{ext}"),
+        _ => format!("{file_name}-{generation}"),
+    };
+    match parent {
+        Some(p) if !p.as_os_str().is_empty() => p.join(new_name),
+        _ => PathBuf::from(new_name),
+    }
+}
+
+/// Atomically rename a freshly-created per-generation SHM file into the
+/// canonical "current" path.
+///
+/// POSIX `rename(2)` is atomic on the same filesystem: any process opening
+/// `canonical_path` after the call sees either the old or the new file,
+/// never a partial state. Existing readers that already mmap'd the
+/// previous file at `canonical_path` continue to operate on the previous
+/// inode (kept alive by the mmap reference), so they never see torn data
+/// either. New readers that re-open `canonical_path` pick up the new
+/// generation.
+///
+/// The two paths must be on the same filesystem; otherwise `rename(2)`
+/// degrades to copy+unlink and loses atomicity. Both per-generation files
+/// and the canonical "current" file should live in the same SHM mount
+/// (typically `/dev/shm` or `/shm/rtdb`).
+pub fn commit_generation_swap(staging_path: &Path, canonical_path: &Path) -> Result<()> {
+    std::fs::rename(staging_path, canonical_path)
+        .with_context(|| format!("rename {staging_path:?} → {canonical_path:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generation_path_appends_before_extension() {
+        let p = generation_file_path(Path::new("/dev/shm/voltage-rtdb.shm"), 42);
+        assert_eq!(p, PathBuf::from("/dev/shm/voltage-rtdb-42.shm"));
+    }
+
+    #[test]
+    fn generation_path_handles_no_extension() {
+        let p = generation_file_path(Path::new("/tmp/voltage"), 7);
+        assert_eq!(p, PathBuf::from("/tmp/voltage-7"));
+    }
+
+    #[test]
+    fn generation_path_handles_multi_extension() {
+        // foo.shm.bak → foo.shm-N.bak (suffix injected before final ext)
+        let p = generation_file_path(Path::new("/tmp/voltage.shm.bak"), 3);
+        assert_eq!(p, PathBuf::from("/tmp/voltage.shm-3.bak"));
+    }
+
+    #[test]
+    fn generation_path_handles_relative_path() {
+        let p = generation_file_path(Path::new("voltage.shm"), 1);
+        assert_eq!(p, PathBuf::from("voltage-1.shm"));
+    }
+
+    #[test]
+    fn generation_path_handles_hidden_file() {
+        // Leading-dot file: ".voltage" has empty stem before the dot — we
+        // treat the whole name as the stem and append the generation.
+        let p = generation_file_path(Path::new("/tmp/.voltage"), 5);
+        assert_eq!(p, PathBuf::from("/tmp/.voltage-5"));
+    }
+
+    #[test]
+    fn commit_swap_renames_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().join("voltage-rtdb.shm");
+        let staging = generation_file_path(&canonical, 1);
+
+        // Pre-populate canonical to simulate a "current" file already in
+        // place — the swap should overwrite it.
+        std::fs::write(&canonical, b"OLD").unwrap();
+        std::fs::write(&staging, b"NEW").unwrap();
+
+        commit_generation_swap(&staging, &canonical).unwrap();
+
+        assert_eq!(std::fs::read(&canonical).unwrap(), b"NEW");
+        assert!(
+            !staging.exists(),
+            "staging file should be gone after rename"
+        );
+    }
+
+    #[test]
+    fn commit_swap_works_when_canonical_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().join("voltage-rtdb.shm");
+        let staging = generation_file_path(&canonical, 1);
+
+        std::fs::write(&staging, b"NEW").unwrap();
+        // canonical does NOT exist — first-create case.
+        commit_generation_swap(&staging, &canonical).unwrap();
+
+        assert_eq!(std::fs::read(&canonical).unwrap(), b"NEW");
+    }
 }

--- a/libs/voltage-rtdb-shm/src/shm_handle.rs
+++ b/libs/voltage-rtdb-shm/src/shm_handle.rs
@@ -20,6 +20,7 @@
 use std::sync::Arc;
 
 use crate::channel_points::ChannelPointCounts;
+use crate::core::config::{commit_generation_swap, generation_file_path};
 use crate::reverse_index::ReverseSlotIndex;
 use crate::shared_config::{ChannelToSlotIndex, SharedConfig};
 use crate::unified_shm::UnifiedWriter;
@@ -110,6 +111,84 @@ impl ShmHandle {
         Ok(())
     }
 
+    /// Rebuild via per-generation file + atomic rename — the Step 3
+    /// alternative to `rebuild()`'s in-place `reconfigure_existing` path.
+    ///
+    /// Flow:
+    /// 1. Compute a unique staging path under the same directory using a
+    ///    nanosecond-based generation seed. Wall-clock nanoseconds make
+    ///    collisions effectively impossible in practice and, since
+    ///    `commit_generation_swap` does an unconditional rename, even a
+    ///    collision would only overwrite a stale file (never current).
+    /// 2. Create a fresh `UnifiedWriter` at the staging path — this is a
+    ///    brand-new file with all slots already initialized to the
+    ///    unwritten-NaN sentinel; no in-place mutation of any live mmap.
+    /// 3. Flush the new mmap to its backing file so the data is durable
+    ///    before we publish the file.
+    /// 4. `commit_generation_swap(staging → canonical)`: POSIX `rename(2)`
+    ///    atomically replaces the canonical path. Any reader still
+    ///    holding a mmap of the previous canonical file keeps reading
+    ///    its data (kernel-managed inode lifetime).
+    /// 5. ArcSwap the local layout to the new writer.
+    ///
+    /// **Note**: this updates the *local* layout immediately. Other
+    /// processes that have already mmap'd the canonical path will not
+    /// learn about the new file until they re-open. PR 3 of Step 3 will
+    /// add the cross-service prepare/commit protocol that triggers
+    /// modsrv to re-open. Until then, callers using `rebuild_via_swap`
+    /// must arrange their own modsrv notification (e.g. via the existing
+    /// `ChannelManager` rebuild_trigger, or by explicit HTTP signal).
+    pub fn rebuild_via_swap(&self, channel_points: &ChannelPointCounts) -> anyhow::Result<()> {
+        let canonical = self.config.path().to_path_buf();
+
+        let staging_seq = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(1);
+        let staging_path = generation_file_path(&canonical, staging_seq);
+
+        let staging_config = self.config.clone().with_path(staging_path.clone());
+
+        // Step 1-2: build new SHM at staging path. UnifiedWriter::create
+        // initializes the header, every slot to NaN sentinel, and flushes
+        // before returning.
+        let writer = UnifiedWriter::create(&staging_config, channel_points)
+            .map_err(|e| anyhow::anyhow!("create staging SHM at {staging_path:?}: {e}"))?;
+
+        // Step 3: ensure data is on disk before publishing.
+        writer.flush().map_err(|e| {
+            anyhow::anyhow!("flush staging SHM at {staging_path:?} before swap: {e}")
+        })?;
+
+        // Step 4: atomic rename. After this point, fresh opens of
+        // `canonical` see the new file; existing mmaps of the old
+        // canonical keep working on the previous inode.
+        commit_generation_swap(&staging_path, &canonical)?;
+
+        // Step 5: rebuild the local layout pointing at the new writer.
+        // We need to re-derive the writer from the canonical path so the
+        // SlotWriter's stored `path` field matches reality; the
+        // `writer` we just created knows itself as `staging_path` which
+        // no longer exists.
+        let writer =
+            UnifiedWriter::open_for_actions(&self.config, channel_points).map_err(|e| {
+                anyhow::anyhow!("re-open new SHM at canonical {canonical:?} as writer: {e}")
+            })?;
+        let slot_count = writer.slot_count();
+        let index = ChannelToSlotIndex::from_unified_writer(&writer);
+        let index_len = index.len();
+        let layout = Arc::new(ShmLayout::new(writer, index));
+        let reverse_len = layout.reverse_index.mapped_count();
+
+        self.layout.store(Some(layout));
+
+        info!(
+            "ShmHandle: rebuilt via atomic swap (staging={:?}) — {} slots, {} index, {} reverse",
+            staging_path, slot_count, index_len, reverse_len
+        );
+        Ok(())
+    }
+
     /// Get the SharedConfig.
     pub fn config(&self) -> &SharedConfig {
         &self.config
@@ -142,6 +221,53 @@ mod tests {
 
     fn test_config(path: std::path::PathBuf) -> SharedConfig {
         SharedConfig::default().with_path(path).with_max_slots(8)
+    }
+
+    #[test]
+    fn rebuild_via_swap_replaces_canonical_file_and_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().join("test.shm");
+        let config = test_config(canonical.clone());
+
+        let initial_counts = counts(1001);
+        let writer = UnifiedWriter::create(&config, &initial_counts).unwrap();
+        let initial_inode = std::fs::metadata(&canonical).unwrap().len(); // proxy for "file exists"
+        assert!(initial_inode > 0);
+        let index = ChannelToSlotIndex::from_unified_writer(&writer);
+        let handle = ShmHandle::new(config, writer, index);
+
+        // Sanity: layout starts on channel 1001.
+        let layout = handle.layout_arc().unwrap();
+        assert_eq!(layout.index.lookup(1001, PointType::Telemetry, 0), Some(0));
+
+        // Swap-rebuild to a new topology with channel 2002.
+        let new_counts = counts(2002);
+        handle.rebuild_via_swap(&new_counts).unwrap();
+
+        // The canonical file still exists (POSIX rename replaced it).
+        assert!(canonical.exists());
+
+        // Local layout now reflects the new topology.
+        let layout = handle.layout_arc().unwrap();
+        assert!(layout.index.lookup(1001, PointType::Telemetry, 0).is_none());
+        assert_eq!(layout.index.lookup(2002, PointType::Telemetry, 0), Some(0));
+        let origin = layout.reverse_index.get(0).unwrap();
+        assert_eq!(origin.channel_id, 2002);
+        assert_eq!(origin.point_type, PointType::Telemetry);
+
+        // No staging files left behind.
+        let stragglers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name().to_string_lossy().starts_with("test-")
+                    && e.file_name().to_string_lossy().ends_with(".shm")
+            })
+            .collect();
+        assert!(
+            stragglers.is_empty(),
+            "rebuild_via_swap left staging files behind: {stragglers:?}"
+        );
     }
 
     #[test]

--- a/libs/voltage-rtdb-shm/src/unified_shm.rs
+++ b/libs/voltage-rtdb-shm/src/unified_shm.rs
@@ -1226,6 +1226,35 @@ impl crate::core::slot_io::SlotIo for UnifiedWriter {
     }
 }
 
+// UnifiedReader implements only the read view; it does not implement
+// SlotIoWrite, so `&dyn SlotIo` taken from a reader cannot mutate.
+impl crate::core::slot_io::SlotIo for UnifiedReader {
+    #[inline]
+    fn slot_count(&self) -> usize {
+        crate::core::slot_io::SlotIo::slot_count(&self.inner)
+    }
+
+    #[inline]
+    fn read_slot(&self, index: usize) -> Option<crate::core::slot_io::SlotRead> {
+        crate::core::slot_io::SlotIo::read_slot(&self.inner, index)
+    }
+
+    #[inline]
+    fn generation(&self) -> u64 {
+        crate::core::slot_io::SlotIo::generation(&self.inner)
+    }
+
+    #[inline]
+    fn writer_heartbeat(&self) -> u64 {
+        crate::core::slot_io::SlotIo::writer_heartbeat(&self.inner)
+    }
+
+    #[inline]
+    fn header(&self) -> &UnifiedHeader {
+        crate::core::slot_io::SlotIo::header(&self.inner)
+    }
+}
+
 impl crate::core::slot_io::SlotIoWrite for UnifiedWriter {
     #[inline]
     fn write_slot(&self, index: usize, value: f64, raw: f64, timestamp_ms: u64) -> bool {

--- a/libs/voltage-rtdb-shm/tests/test_generation_swap.rs
+++ b/libs/voltage-rtdb-shm/tests/test_generation_swap.rs
@@ -1,0 +1,130 @@
+//! Atomic per-generation file swap mechanism (Step 3 PR 1).
+//!
+//! Validates the building blocks that PR 2 will assemble into the full
+//! comsrv/modsrv reload protocol:
+//!
+//! - `generation_file_path` derives staging paths from the canonical path
+//! - `UnifiedWriter::create` can be pointed at an arbitrary path via
+//!   `SharedConfig::with_path`
+//! - `commit_generation_swap` atomically replaces the canonical file with
+//!   the staging file
+//! - Critical property: **an existing reader holding a mmap of the previous
+//!   file continues to see its data** after the swap, while a freshly
+//!   opened reader sees the new file. This is what makes the design
+//!   tear-free without cross-process coordination — the POSIX inode lives
+//!   as long as any mmap references it.
+
+#![allow(clippy::disallowed_methods)]
+
+use std::collections::BTreeMap;
+use tempfile::tempdir;
+use voltage_rtdb_shm::{
+    ChannelPointCounts, SharedConfig, SlotIo, UnifiedReader, UnifiedWriter,
+    core::config::{commit_generation_swap, generation_file_path},
+};
+
+fn config_at(path: std::path::PathBuf) -> SharedConfig {
+    SharedConfig::default().with_path(path).with_max_slots(256)
+}
+
+fn counts_v1() -> ChannelPointCounts {
+    let mut map = BTreeMap::new();
+    map.insert(100u32, [4u32, 0, 0, 0]); // 4 telemetry points
+    ChannelPointCounts::from_map(map)
+}
+
+fn counts_v2() -> ChannelPointCounts {
+    let mut map = BTreeMap::new();
+    map.insert(100u32, [4u32, 0, 0, 0]);
+    map.insert(200u32, [2u32, 0, 0, 0]); // adds channel 200 with 2 points
+    ChannelPointCounts::from_map(map)
+}
+
+/// End-to-end: create gen 1 → open reader R1 → create gen 2 staging →
+/// commit swap → R1 still sees gen 1 data (mmap holds inode) → new reader
+/// R2 opened at canonical path sees gen 2 layout.
+#[test]
+fn atomic_swap_preserves_existing_readers() {
+    let dir = tempdir().unwrap();
+    let canonical = dir.path().join("voltage-rtdb.shm");
+
+    // --- Phase 1: create generation 1 at canonical path ---
+    let cfg1 = config_at(canonical.clone());
+    let cp1 = counts_v1();
+    let writer1 = UnifiedWriter::create(&cfg1, &cp1).unwrap();
+    let gen1_routing_hash = SlotIo::header(&writer1)
+        .routing_hash
+        .load(std::sync::atomic::Ordering::Acquire);
+
+    // Write a sentinel value into channel 100, point 0
+    let slot = writer1.lookup(100, 0, 0).expect("lookup gen1 slot");
+    writer1.set_direct(slot, 99.9, 0.0, 1_000_000);
+
+    // --- Phase 2: open reader R1 ---
+    let reader1 = UnifiedReader::open(&cfg1, &cp1).unwrap();
+    let r1_routing_hash = SlotIo::header(&reader1)
+        .routing_hash
+        .load(std::sync::atomic::Ordering::Acquire);
+    assert_eq!(r1_routing_hash, gen1_routing_hash);
+
+    let (value_before, _ts) = reader1.get_channel(100, 0, 0).expect("R1 reads gen1");
+    assert_eq!(value_before, 99.9);
+
+    // --- Phase 3: create generation 2 at staging path ---
+    let staging = generation_file_path(&canonical, 2);
+    let cfg2 = config_at(staging.clone());
+    let cp2 = counts_v2();
+    let writer2 = UnifiedWriter::create(&cfg2, &cp2).unwrap();
+    let gen2_routing_hash = SlotIo::header(&writer2)
+        .routing_hash
+        .load(std::sync::atomic::Ordering::Acquire);
+
+    assert_ne!(
+        gen1_routing_hash, gen2_routing_hash,
+        "different channel_points must produce different routing_hash"
+    );
+
+    // Write a sentinel value into channel 200, point 0 (new channel in gen 2)
+    let new_slot = writer2.lookup(200, 0, 0).expect("lookup gen2 slot");
+    writer2.set_direct(new_slot, 42.0, 0.0, 2_000_000);
+
+    // Drop writer2 to release the mmap before rename (some platforms need this)
+    drop(writer2);
+
+    // --- Phase 4: commit swap (atomic rename) ---
+    commit_generation_swap(&staging, &canonical).unwrap();
+    assert!(
+        !staging.exists(),
+        "staging file must be consumed by the rename"
+    );
+    assert!(canonical.exists(), "canonical must now point at gen 2 file");
+
+    // --- Phase 5: R1 still sees gen 1 data ---
+    //
+    // This is the critical property. R1's mmap was created on the gen 1
+    // inode. After rename, that inode is unlinked from the directory but
+    // remains live in memory because R1's mmap holds a reference. R1
+    // continues to read gen 1 values without observing the swap at all.
+    let r1_routing_hash_after = SlotIo::header(&reader1)
+        .routing_hash
+        .load(std::sync::atomic::Ordering::Acquire);
+    assert_eq!(
+        r1_routing_hash_after, gen1_routing_hash,
+        "R1's mmap must still reflect gen 1"
+    );
+    let (value_after, _ts) = reader1.get_channel(100, 0, 0).expect("R1 still reads gen1");
+    assert_eq!(value_after, 99.9);
+
+    // --- Phase 6: a freshly-opened reader sees gen 2 ---
+    let reader2 = UnifiedReader::open(&cfg1, &cp2).unwrap();
+    let r2_routing_hash = SlotIo::header(&reader2)
+        .routing_hash
+        .load(std::sync::atomic::Ordering::Acquire);
+    assert_eq!(
+        r2_routing_hash, gen2_routing_hash,
+        "R2 opened at canonical path must see gen 2 routing"
+    );
+
+    let (gen2_value, _ts) = reader2.get_channel(200, 0, 0).expect("R2 reads gen2 chan");
+    assert_eq!(gen2_value, 42.0);
+}


### PR DESCRIPTION
## Summary

PR 1 of 3 for **Step 3** of the SHM decoupling roadmap: eliminate the in-place `reconfigure_existing` race condition by switching reload to a per-generation file + atomic rename model.

**This PR is additive and zero-behavior-change.** It ships the building blocks; PR 2 wires them into the comsrv/modsrv reload protocol; PR 3 replaces `reconfigure_existing` call sites and adds crash recovery + file cleanup.

## Why

Today's `UnifiedWriter::reconfigure_existing` mutates the SHM mmap in place:

1. Bumps `writer_generation` to odd (sentinel for "reconfigure in progress")
2. Zeros the slot region in place
3. Re-initializes slots to NaN sentinel
4. Updates `slot_count` / `routing_hash` in the header
5. Bumps `writer_generation` back to even

During steps 2-4 any modsrv reader holding a mmap of the same file can see torn / all-zero slot data. The seqlock retry catches torn per-slot bytes, but the `slot_count` header field is mid-flight too — so the count of slots a reader iterates over can itself be wrong. modsrv's `expected_generation != current_generation` check is *post hoc* and doesn't prevent the bad read from happening.

The fix is to **never mutate a live mmap**. Each topology change materializes a fresh per-generation file at `voltage-rtdb-{N}.shm`, then a POSIX `rename(2)` atomically swaps it into the canonical `voltage-rtdb.shm` path. Existing readers continue to operate on the previous inode (kept live by their mmap reference); new readers re-opening the canonical path pick up the new generation.

## What's in this PR

| Item | File | Purpose |
|---|---|---|
| `generation_file_path(base, gen) → PathBuf` | `core/config.rs` | Naming helper: `voltage-rtdb.shm` + gen=42 → `voltage-rtdb-42.shm` |
| `commit_generation_swap(staging, canonical) → Result` | `core/config.rs` | POSIX `rename(2)` wrapper with the SAFETY chain documented |
| `impl SlotIo for UnifiedReader` | `unified_shm.rs` | Gap fill — UnifiedReader was missing the trait impl from the SlotReader extraction PR |
| `tests/test_generation_swap.rs` | new | End-to-end inode-property proof |

### The critical property the integration test proves

```
1. Create generation 1 at canonical path, write sentinel value 99.9
2. Open reader R1   ← mmap holds gen-1 inode
3. Create generation 2 at staging path (different ChannelPointCounts)
4. commit_generation_swap(staging → canonical)
5. R1 still reads gen-1 routing_hash + 99.9
6. Newly-opened R2 at canonical sees gen-2 routing_hash + new channels
```

This is the entire reason the design works without per-swap cross-process locking. The kernel keeps the unlinked inode live as long as any mmap references it, so R1 cannot observe the swap at all.

## What this PR does NOT do (PR 2 + PR 3)

- **PR 2** (cross-process protocol): `ShmHandle::rebuild_via_swap`, comsrv `/shm/prepare-swap` + `/shm/commit-swap` HTTP endpoints, modsrv handlers, ArcSwap on both ends. Switches `ShmHandle::rebuild()` from `reconfigure_existing` to the new flow.
- **PR 3** (failure modes + cleanup): old-generation file unlinking after grace period, crash recovery (orphaned per-generation files on comsrv restart), modsrv health-check timeout if commit-swap is not ACKed.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy -p voltage-rtdb-shm --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p voltage-rtdb-shm` — 93 tests pass (was 85; +7 unit config tests, +1 integration test). All pre-existing tests untouched since this PR is additive.
- [ ] On-device validation deferred to after PR 2 (no runtime path changed here)