### PR TITLE
feat(shm): Step 3 PR 2 — switch rebuild to atomic-swap + modsrv inode watcher

### DIFF
--- a/libs/voltage-rtdb-shm/src/shm_handle.rs
+++ b/libs/voltage-rtdb-shm/src/shm_handle.rs
@@ -91,24 +91,23 @@ impl ShmHandle {
 
     /// Rebuild SHM writer and indexes from updated channel point counts.
     ///
-    /// Called after routing reload succeeds. Reconfigures the existing
-    /// SHM file in place, then atomically swaps the coherent layout handle.
-    /// Old objects are dropped when the last reader Guard releases.
+    /// Step 3 of the SHM decoupling roadmap routes this through
+    /// [`rebuild_via_swap`](Self::rebuild_via_swap): a fresh SHM file is
+    /// created at a staging path with all slots initialized to the
+    /// NaN-sentinel, then a POSIX `rename(2)` atomically replaces the
+    /// canonical path. Existing readers in other processes that mmap'd
+    /// the old canonical file keep operating on the now-unlinked inode
+    /// (kept live by their mmap reference) until they re-open. modsrv
+    /// learns of the swap via its inode-watcher task in
+    /// `services/modsrv/src/main.rs`, which fires the existing
+    /// `rebuild_trigger` when it observes a canonical-path inode change.
+    ///
+    /// Compared to the legacy `reconfigure_existing` (now removed from
+    /// this path), no live mmap is ever mutated mid-flight — there is
+    /// no window in which a reader can observe torn `slot_count` or
+    /// partially-zeroed slots.
     pub fn rebuild(&self, channel_points: &ChannelPointCounts) -> anyhow::Result<()> {
-        let writer = UnifiedWriter::reconfigure_existing(&self.config, channel_points)?;
-        let slot_count = writer.slot_count();
-        let index = ChannelToSlotIndex::from_unified_writer(&writer);
-        let index_len = index.len();
-        let layout = Arc::new(ShmLayout::new(writer, index));
-        let reverse_len = layout.reverse_index.mapped_count();
-
-        self.layout.store(Some(layout));
-
-        info!(
-            "ShmHandle: rebuilt with {} slots, {} index mappings, {} reverse mappings",
-            slot_count, index_len, reverse_len
-        );
-        Ok(())
+        self.rebuild_via_swap(channel_points)
     }
 
     /// Rebuild via per-generation file + atomic rename — the Step 3

--- a/services/comsrv/src/store/shm_redis_sync.rs
+++ b/services/comsrv/src/store/shm_redis_sync.rs
@@ -147,13 +147,19 @@ impl<R: Rtdb> ShmRedisSync<R> {
             return;
         }
 
-        // Reconfigure-in-progress sentinel: comsrv flips writer_generation
-        // to an odd value while it is clearing slots in reconfigure_existing.
-        // Reading slots during this window would yield all-zero garbage
-        // (the byte-fill in progress). Skip this tick and retry next
-        // iteration — the even parity returns once reconfigure completes,
-        // and the subsequent layout/content-hash change will already force
-        // a full_seq reset for the new layout.
+        // Reconfigure-in-progress sentinel (defensive).
+        //
+        // Historically, comsrv flipped `writer_generation` to an odd value
+        // while clearing slots in the legacy in-place `reconfigure_existing`
+        // path; reads during that window could yield torn data. Step 3
+        // (PR #93 + this branch) replaced that with `ShmHandle::rebuild_via_swap`
+        // — a brand-new file at a staging path, then a POSIX rename(2)
+        // atomically swaps it in. There is no in-flight-mutation window any
+        // more, and `writer_generation` always stays even.
+        //
+        // The check is kept as cheap defense-in-depth: if any future code
+        // path resurrects an in-place mutation pattern, this skip prevents
+        // Redis sync from publishing torn rows.
         if writer.generation() & 1 == 1 {
             trace!("ShmRedisSync: reconfigure in progress (odd generation), skipping tick");
             self.tick_count += 1;

--- a/services/modsrv/src/main.rs
+++ b/services/modsrv/src/main.rs
@@ -295,6 +295,98 @@ async fn main() -> Result<()> {
         });
     }
 
+    // Spawn SHM canonical-path inode watcher.
+    //
+    // Step 3 of the SHM decoupling roadmap replaces in-place
+    // reconfigure_existing with `ShmHandle::rebuild_via_swap`: comsrv
+    // creates a new SHM file at a staging path, then POSIX-renames it
+    // over the canonical path. modsrv's existing UnifiedWriter is still
+    // mmap'd to the *previous* inode (now unlinked but live in memory),
+    // so its `writer.generation()` reads stay constant — the existing
+    // dispatch-time generation-mismatch check never fires for swap-based
+    // reloads.
+    //
+    // To learn about the swap, periodically `stat(canonical_path)` and
+    // compare the inode against a cached baseline. On change, fire the
+    // existing `rebuild_trigger` Notify, which the auto-rebuild task
+    // above already handles end-to-end (open_for_actions on the new
+    // inode, swap into ShmDispatch via set_writer).
+    {
+        use std::os::unix::fs::MetadataExt;
+        const WATCH_INTERVAL: Duration = Duration::from_secs(5);
+
+        let watch_notify = state.shm_dispatch.rebuild_trigger();
+        let watch_path = shm_config.path().to_path_buf();
+        let watch_token = shutdown_token.clone();
+
+        tokio::spawn(async move {
+            // Baseline: capture initial inode (None if canonical does not
+            // yet exist — comsrv may not have created it yet). We only
+            // fire on a *change* from a known-good value to avoid a
+            // spurious rebuild during cold boot.
+            let mut last_inode = std::fs::metadata(&watch_path).ok().map(|m| m.ino());
+            if let Some(ino) = last_inode {
+                info!(
+                    "SHM inode watcher: baseline inode={} for {:?}",
+                    ino, watch_path
+                );
+            } else {
+                info!(
+                    "SHM inode watcher: canonical path {:?} not yet present; will start tracking once it appears",
+                    watch_path
+                );
+            }
+
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(WATCH_INTERVAL) => {},
+                    _ = watch_token.cancelled() => break,
+                }
+
+                let current_inode = match std::fs::metadata(&watch_path) {
+                    Ok(m) => Some(m.ino()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+                    Err(e) => {
+                        warn!(
+                            "SHM inode watcher: stat {:?} failed (non-NotFound): {}",
+                            watch_path, e
+                        );
+                        continue;
+                    },
+                };
+
+                match (last_inode, current_inode) {
+                    (Some(old), Some(new)) if old != new => {
+                        info!(
+                            "SHM inode watcher: canonical path inode changed {} → {} \
+                             (comsrv likely performed an atomic-swap reload); \
+                             triggering writer rebuild",
+                            old, new
+                        );
+                        last_inode = Some(new);
+                        watch_notify.notify_one();
+                    },
+                    (None, Some(new)) => {
+                        info!(
+                            "SHM inode watcher: canonical path now exists (inode={}); \
+                             tracking baseline",
+                            new
+                        );
+                        last_inode = Some(new);
+                    },
+                    (Some(_), None) => {
+                        warn!(
+                            "SHM inode watcher: canonical path {:?} disappeared — \
+                             comsrv may be mid-restart; keeping prior baseline",
+                            watch_path
+                        );
+                    },
+                    _ => {}, // no change
+                }
+            }
+        });
+    }
+
     // Spawn channel health refresh task: mirrors `comsrv:online` into a
     // process-local cache so the M2C control gate in execute_action() can reject
     // writes targeting offline channels without per-call Redis round-trips.


### PR DESCRIPTION
## Summary

PR 2 of 3 for **Step 3** (eliminate in-place `reconfigure_existing` race). Stacks on PR #93 (already merged) which shipped the per-generation file mechanism and `ShmHandle::rebuild_via_swap` as an additive new method. This PR makes that method the live path:

1. `ShmHandle::rebuild()` now delegates to `rebuild_via_swap` — the legacy `reconfigure_existing` is no longer called from any production path.
2. modsrv gains a 5-second polling `stat(2)` watcher on the canonical SHM path that triggers the existing `rebuild_trigger` on inode change, so modsrv re-opens its `UnifiedWriter` after every comsrv-side atomic swap.

## Why the modsrv watcher is needed

Atomic-swap reload works like this on the comsrv side:

```
comsrv creates voltage-rtdb-{nanos}.shm  (fresh file, NaN sentinels)
comsrv POSIX rename(2) → voltage-rtdb.shm  (atomic replace)
comsrv ArcSwap layout → new writer
```

After the rename, comsrv's `UnifiedWriter` points at the new inode. But modsrv's `UnifiedWriter` (from `open_for_actions`) is mmap'd to the **previous** inode. That inode is unlinked from the filesystem but stays live in memory because modsrv's mmap reference keeps it alive — so `modsrv_writer.generation()` keeps reading the *old* `writer_generation` field from the *old* file. The existing dispatch-time generation-mismatch check in `ShmDispatch::dispatch` never fires.

Two options for closing the loop:
- **Active push**: a comsrv → modsrv HTTP control-plane signal (`/shm/swap-committed`)
- **Passive pull**: modsrv polls `stat(canonical_path).st_ino` and fires its own rebuild trigger on change

This PR ships the passive variant. PR 3 may add the active variant if sub-second hand-off matters for some operational scenario; today's reload cadence is operator-driven and infrequent so a 5-second worst-case window is acceptable.

## Files

| File | Change |
|---|---|
| `libs/voltage-rtdb-shm/src/shm_handle.rs` | `rebuild()` body collapses to `self.rebuild_via_swap(...)`. Doc explains the new semantics. |
| `services/modsrv/src/main.rs` | New tokio task: every 5s, `stat(canonical_path).st_ino`; on change, `rebuild_trigger.notify_one()`. Handles cold-boot (path not yet present), mid-swap (path momentarily missing), and steady-state. |
| `services/comsrv/src/store/shm_redis_sync.rs` | Stale comment about `reconfigure_existing` rewritten. The odd-generation skip itself is kept as defense-in-depth. |

## What this PR does NOT do (PR 3, optional)

- **Delete `reconfigure_existing`** — kept in `unified_shm.rs` because two unit tests still exercise its odd/even gating; removing both the function and the tests is a separate cleanup.
- **Old-generation file cleanup** — every swap leaves a staging file lifetime tied to whoever still mmap's the *previous* inode. PR 3 can add a grace-period unlinker that GCs old files after a known boundary (e.g., a sync barrier or a TTL after all known readers have re-opened).
- **HTTP `/shm/swap-committed` push notification** — only needed if 5s polling latency becomes a problem.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy -p voltage-rtdb-shm -p modsrv --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p voltage-rtdb-shm` — 94 tests pass. The legacy `rebuild_replaces_reverse_index_with_layout` test now runs through the swap path via the `rebuild()` delegation and passes, proving both paths produce equivalent layout state.
- [ ] **On-device validation required before next release**: `monarch services restart && monarch sync && curl /health` on both comsrv and modsrv; observe modsrv logs for "SHM inode watcher: canonical path inode changed N → M (...); triggering writer rebuild" within 5s of any reload.