### PR TITLE
feat(shm): Step 3 PR 3 — remove legacy reconfigure_existing + orphan cleanup

### DIFF
--- a/libs/voltage-rtdb-shm/src/core/config.rs
+++ b/libs/voltage-rtdb-shm/src/core/config.rs
@@ -93,6 +93,83 @@ pub fn generation_file_path(base: &Path, generation: u64) -> PathBuf {
     }
 }
 
+/// Best-effort cleanup of orphaned per-generation SHM staging files.
+///
+/// `rebuild_via_swap` creates a fresh file at `generation_file_path(canonical, N)`,
+/// flushes, then `rename(2)`s it over `canonical`. The rename consumes
+/// the staging filename atomically, so under steady-state operation no
+/// `*-{N}.{ext}` files ever persist. They can only appear if a process
+/// crashed between the create and the rename — typically a comsrv
+/// SIGKILL during reload.
+///
+/// This helper is meant to be called at comsrv startup, before any
+/// new SHM file is created. It scans `canonical.parent()` for entries
+/// whose name matches `{stem}-{digits}.{ext}` (the exact pattern
+/// produced by `generation_file_path`) and unlinks them. Files that
+/// were rename'd over `canonical` are unreachable through this scan
+/// (the staging name no longer exists), so this is safe regardless of
+/// concurrent readers in other processes.
+///
+/// Returns the number of orphan files removed. Individual unlink
+/// failures are logged via `tracing::warn` but do not abort the scan,
+/// because a single permission error should not block startup.
+pub fn cleanup_orphan_generation_files(canonical: &Path) -> Result<usize> {
+    let parent = canonical
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("canonical path has no parent: {canonical:?}"))?;
+    if parent.as_os_str().is_empty() {
+        return Ok(0);
+    }
+    let file_name = canonical
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow::anyhow!("canonical path has no file name: {canonical:?}"))?;
+
+    let (stem, ext_suffix): (String, String) = match file_name.rsplit_once('.') {
+        Some((s, e)) if !s.is_empty() => (s.to_string(), format!(".{e}")),
+        _ => (file_name.to_string(), String::new()),
+    };
+    let prefix = format!("{stem}-");
+
+    let read_dir = match std::fs::read_dir(parent) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => {
+            return Err(anyhow::Error::new(e).context(format!("read_dir {parent:?}")));
+        },
+    };
+
+    let mut removed = 0;
+    for entry in read_dir.flatten() {
+        let entry_name_os = entry.file_name();
+        let Some(name) = entry_name_os.to_str() else {
+            continue;
+        };
+        if !name.starts_with(&prefix) || !name.ends_with(&ext_suffix) {
+            continue;
+        }
+        if name.len() <= prefix.len() + ext_suffix.len() {
+            continue;
+        }
+        let middle = &name[prefix.len()..name.len() - ext_suffix.len()];
+        if middle.is_empty() || !middle.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        // Matched pattern {stem}-{digits}{.ext}. Unlink.
+        let path = entry.path();
+        match std::fs::remove_file(&path) {
+            Ok(_) => {
+                removed += 1;
+                tracing::info!("removed orphan generation SHM file: {path:?}");
+            },
+            Err(e) => {
+                tracing::warn!("failed to remove orphan generation SHM file {path:?}: {e}");
+            },
+        }
+    }
+    Ok(removed)
+}
+
 /// Atomically rename a freshly-created per-generation SHM file into the
 /// canonical "current" path.
 ///
@@ -168,6 +245,51 @@ mod tests {
             !staging.exists(),
             "staging file should be gone after rename"
         );
+    }
+
+    #[test]
+    fn cleanup_orphan_removes_matching_files_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().join("voltage-rtdb.shm");
+
+        // Plant a mix:
+        //   - canonical itself (must be preserved)
+        //   - 3 orphan generation files (must be removed)
+        //   - a similar-prefix-but-not-numeric file (must be preserved)
+        //   - a different-prefix file (must be preserved)
+        std::fs::write(&canonical, b"current").unwrap();
+        std::fs::write(dir.path().join("voltage-rtdb-1.shm"), b"orphan1").unwrap();
+        std::fs::write(dir.path().join("voltage-rtdb-42.shm"), b"orphan42").unwrap();
+        std::fs::write(dir.path().join("voltage-rtdb-999999.shm"), b"orphan_big").unwrap();
+        std::fs::write(dir.path().join("voltage-rtdb-alpha.shm"), b"non-numeric").unwrap();
+        std::fs::write(dir.path().join("voltage-other.shm"), b"unrelated").unwrap();
+
+        let removed = cleanup_orphan_generation_files(&canonical).unwrap();
+        assert_eq!(removed, 3);
+
+        assert!(canonical.exists(), "canonical must be preserved");
+        assert!(
+            dir.path().join("voltage-rtdb-alpha.shm").exists(),
+            "non-numeric suffix must not match"
+        );
+        assert!(
+            dir.path().join("voltage-other.shm").exists(),
+            "different-prefix file must not match"
+        );
+        for n in [1u32, 42, 999999] {
+            assert!(
+                !dir.path().join(format!("voltage-rtdb-{n}.shm")).exists(),
+                "orphan {n} should be removed"
+            );
+        }
+    }
+
+    #[test]
+    fn cleanup_orphan_returns_zero_when_dir_missing() {
+        // Canonical path under a non-existent directory — read_dir errors
+        // with NotFound, which the helper turns into Ok(0).
+        let canonical = std::path::PathBuf::from("/tmp/does-not-exist-step3/voltage-rtdb.shm");
+        assert_eq!(cleanup_orphan_generation_files(&canonical).unwrap(), 0);
     }
 
     #[test]

--- a/libs/voltage-rtdb-shm/src/shm_handle.rs
+++ b/libs/voltage-rtdb-shm/src/shm_handle.rs
@@ -91,24 +91,23 @@ impl ShmHandle {
 
     /// Rebuild SHM writer and indexes from updated channel point counts.
     ///
-    /// Called after routing reload succeeds. Reconfigures the existing
-    /// SHM file in place, then atomically swaps the coherent layout handle.
-    /// Old objects are dropped when the last reader Guard releases.
+    /// Step 3 of the SHM decoupling roadmap routes this through
+    /// [`rebuild_via_swap`](Self::rebuild_via_swap): a fresh SHM file is
+    /// created at a staging path with all slots initialized to the
+    /// NaN-sentinel, then a POSIX `rename(2)` atomically replaces the
+    /// canonical path. Existing readers in other processes that mmap'd
+    /// the old canonical file keep operating on the now-unlinked inode
+    /// (kept live by their mmap reference) until they re-open. modsrv
+    /// learns of the swap via its inode-watcher task in
+    /// `services/modsrv/src/main.rs`, which fires the existing
+    /// `rebuild_trigger` when it observes a canonical-path inode change.
+    ///
+    /// Compared to the legacy `reconfigure_existing` (now removed from
+    /// this path), no live mmap is ever mutated mid-flight — there is
+    /// no window in which a reader can observe torn `slot_count` or
+    /// partially-zeroed slots.
     pub fn rebuild(&self, channel_points: &ChannelPointCounts) -> anyhow::Result<()> {
-        let writer = UnifiedWriter::reconfigure_existing(&self.config, channel_points)?;
-        let slot_count = writer.slot_count();
-        let index = ChannelToSlotIndex::from_unified_writer(&writer);
-        let index_len = index.len();
-        let layout = Arc::new(ShmLayout::new(writer, index));
-        let reverse_len = layout.reverse_index.mapped_count();
-
-        self.layout.store(Some(layout));
-
-        info!(
-            "ShmHandle: rebuilt with {} slots, {} index mappings, {} reverse mappings",
-            slot_count, index_len, reverse_len
-        );
-        Ok(())
+        self.rebuild_via_swap(channel_points)
     }
 
     /// Rebuild via per-generation file + atomic rename — the Step 3

--- a/libs/voltage-rtdb-shm/src/unified_shm.rs
+++ b/libs/voltage-rtdb-shm/src/unified_shm.rs
@@ -35,7 +35,7 @@ use anyhow::{Context, Result, bail};
 use memmap2::MmapOptions;
 use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering, fence};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use voltage_model::PointType;
 use voltage_routing::RoutingCache;
 
@@ -126,28 +126,6 @@ fn verify_slot_count(file_slot_count: usize, calculated_slots: usize) -> Result<
         );
     }
     Ok(())
-}
-
-/// Validate a shared memory header for writer-side reconfiguration.
-///
-/// Unlike `validate_shm_header`, this intentionally does not verify
-/// `routing_hash` because the caller is about to replace it.
-fn validate_reconfigurable_header(header: &UnifiedHeader) -> Result<u32> {
-    if header.magic != UNIFIED_MAGIC {
-        bail!(
-            "Invalid magic: expected 0x{:X}, got 0x{:X}",
-            UNIFIED_MAGIC,
-            header.magic
-        );
-    }
-    if header.version != UNIFIED_VERSION {
-        bail!(
-            "Version mismatch: expected {}, got {}",
-            UNIFIED_VERSION,
-            header.version
-        );
-    }
-    Ok(header.max_slots)
 }
 
 // The previous `impl_shm_accessors!` macro is gone. Slot-level accessors
@@ -533,155 +511,6 @@ impl UnifiedWriter {
             .flush()
             .context("Failed to flush mmap before snapshot")?;
         self.inner.save_snapshot(path)
-    }
-
-    /// Reconfigure the existing SHM file in place for updated channel point counts.
-    ///
-    /// This keeps the same underlying file/inode alive so existing mmaps are not
-    /// invalidated by truncation. All point slots are cleared before the new
-    /// layout is published to avoid stale values being interpreted as new points.
-    pub fn reconfigure_existing(
-        config: &SharedConfig,
-        channel_points: &ChannelPointCounts,
-    ) -> Result<Self> {
-        let path = config.path();
-
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path)
-            .with_context(|| format!("Failed to open {:?} for SHM reconfigure", path))?;
-
-        // Match the safety gating in open_for_actions / UnifiedReader::open:
-        // a truncated file makes the header cast immediate UB. Without this
-        // check the reconfigure path was the one remaining hole — A.1
-        // patched the three open paths but missed this one.
-        verify_file_min_size(&file, path)?;
-
-        let mut mmap = unsafe {
-            MmapOptions::new()
-                .map_mut(&file)
-                .with_context(|| "Failed to mmap for SHM reconfigure")?
-        };
-
-        // SAFETY: mmap.len() >= sizeof(UnifiedHeader) per verify_file_min_size.
-        let max_slots = {
-            let header = unsafe { &*(mmap.as_ptr() as *const UnifiedHeader) };
-            validate_reconfigurable_header(header)?
-        };
-
-        // Ensure the mmap actually covers the declared slot array. Otherwise
-        // the slot_clear loop and pointer arithmetic below could run off
-        // the mapped region.
-        verify_mmap_covers_slots(mmap.len(), max_slots, path)?;
-
-        // Read old slot_count before allocating new layout
-        let old_slot_count = {
-            let header = unsafe { &*(mmap.as_ptr() as *const UnifiedHeader) };
-            header.slot_count.load(Ordering::Acquire) as usize
-        };
-        if old_slot_count > max_slots as usize {
-            bail!(
-                "Invalid SHM header: slot_count {} exceeds max_slots {}",
-                old_slot_count,
-                max_slots
-            );
-        }
-
-        let (channel_layouts, slot_count) = allocate_layouts(channel_points);
-        if slot_count > max_slots as usize {
-            bail!("Too many slots: {} (max={})", slot_count, max_slots);
-        }
-
-        // Mark reconfigure-in-progress by flipping writer_generation to an
-        // ODD value (low bit = 1). Readers/dispatchers gate on this: any
-        // SHM consumer that reads writer_generation while odd MUST skip
-        // this tick / refuse this dispatch — the slot array is being
-        // cleared and torn reads would produce all-zero garbage. The
-        // matching even-store after the slot init below restores normal
-        // operation with the generation incremented by 2 (odd→even),
-        // which still trips ShmDispatch's mismatch check so the next
-        // dispatch picks up the new layout.
-        {
-            // SAFETY: mmap covers the header; we hold &mut mmap so no
-            // other writer in this process can racing-bump the counter.
-            let header = unsafe { &mut *(mmap.as_mut_ptr() as *mut UnifiedHeader) };
-            let prev = header.writer_generation.fetch_add(1, Ordering::Release);
-            debug_assert!(
-                prev & 1 == 0,
-                "reconfigure entered with odd writer_generation = {} — nested reconfigure?",
-                prev
-            );
-        }
-
-        // Reset only the previously-used slot region (not the entire 2GB sparse file).
-        // Clear max(old, new) slots to cover both old stale data and any new slots.
-        let clear_slots = old_slot_count.max(slot_count);
-        let clear_end = slot_offset() + clear_slots * std::mem::size_of::<PointSlot>();
-        mmap[slot_offset()..clear_end].fill(0);
-
-        // SHM v3 uses NaN, not zero, as the "unwritten" sentinel. The byte
-        // clear above resets seq/dirty/timestamp; this pass restores value/raw
-        // to NaN so routing reload cannot fabricate real 0.0 readings.
-        // SAFETY: clear_end was computed from max(old_slot_count, slot_count),
-        // both bounded by max_slots. The mmap covers max_slots PointSlot values,
-        // and PointSlot is #[repr(C, align(32))].
-        let slots_ptr =
-            unsafe { mmap.as_mut_ptr().add(slot_offset()) as *const crate::core::slot::PointSlot };
-        for i in 0..clear_slots {
-            // SAFETY: i < clear_slots and clear_slots is within the mmap slot region.
-            let slot = unsafe { &*slots_ptr.add(i) };
-            slot.init_unwritten();
-        }
-
-        // FULL BARRIER: ensure all slot resets are globally visible
-        // before the new routing_hash/slot_count are published.
-        // Without this fence, a reader on ARM64 could see the new
-        // routing_hash but read stale slot data.
-        fence(Ordering::SeqCst);
-
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or(std::time::Duration::ZERO)
-            .as_millis() as u64;
-
-        let header = unsafe { &mut *(mmap.as_mut_ptr() as *mut UnifiedHeader) };
-        header
-            .slot_count
-            .store(slot_count as u32, Ordering::Release);
-        header.last_update_ts.store(now_ms, Ordering::Relaxed);
-        header.writer_heartbeat.store(now_ms, Ordering::Relaxed);
-        header
-            .routing_hash
-            .store(channel_points.layout_hash(), Ordering::Release);
-        // Restore even parity (was bumped to odd at the start of this
-        // function). Net effect: generation incremented by 2. ShmDispatch's
-        // mismatch check still trips on the next dispatch (any change),
-        // and the low-bit "reconfigure in progress" sentinel is cleared
-        // so normal consumers resume.
-        let post = header.writer_generation.fetch_add(1, Ordering::Release);
-        debug_assert!(
-            post & 1 == 1,
-            "reconfigure exited with even writer_generation = {} — sentinel logic broken",
-            post
-        );
-
-        // Flush mmap to backing file — ensures cross-process visibility
-        // on systems where mmap coherency isn't guaranteed (H3).
-        mmap.flush()
-            .with_context(|| "Failed to flush mmap after reconfigure")?;
-
-        tracing::info!(
-            "Reconfigured unified shared memory in place: {:?}, slots={}, channels={}",
-            path,
-            slot_count,
-            channel_layouts.iter().filter(|l| l.is_valid()).count()
-        );
-
-        Ok(Self {
-            inner: SlotWriter::from_mmap(mmap, path.to_path_buf(), max_slots, slot_count),
-            channel_layouts,
-        })
     }
 
     /// Restore from snapshot file
@@ -1437,50 +1266,16 @@ mod tests {
         assert!((val - 99.0).abs() < 1e-10);
     }
 
-    #[test]
-    fn test_reconfigure_resets_slots_to_unwritten_nan() {
-        let (_dir, config, channel_points) = setup_test_env();
-        let writer = UnifiedWriter::create(&config, &channel_points).unwrap();
-        let slot = writer.lookup(1001, 0, 0).unwrap();
-        writer.set_direct(slot, 0.0, 0.0, 100);
-        assert!(
-            !writer.slot(slot).is_unwritten(),
-            "real 0.0 write must not be treated as unwritten"
-        );
-        drop(writer);
-
-        let writer = UnifiedWriter::reconfigure_existing(&config, &channel_points).unwrap();
-        let slot = writer.lookup(1001, 0, 0).unwrap();
-        let point = writer.slot(slot);
-        let (value, raw, timestamp) = point.load_consistent().unwrap();
-
-        assert!(value.is_nan(), "reconfigured value must be NaN sentinel");
-        assert!(raw.is_nan(), "reconfigured raw must be NaN sentinel");
-        assert_eq!(timestamp, 0);
-        assert_eq!(point.seq_raw(), 0);
-        assert!(point.is_unwritten());
-    }
-
-    #[test]
-    fn test_reconfigure_rejects_corrupt_slot_count() {
-        let (_dir, config, channel_points) = setup_test_env();
-        let writer = UnifiedWriter::create(&config, &channel_points).unwrap();
-        let max_slots = writer.max_slots();
-        writer
-            .header()
-            .slot_count
-            .store(max_slots.saturating_add(1), Ordering::Release);
-        writer.flush().unwrap();
-        drop(writer);
-
-        let err = match UnifiedWriter::reconfigure_existing(&config, &channel_points) {
-            Ok(_) => panic!("reconfigure must reject corrupt slot_count"),
-            Err(err) => err,
-        };
-        let message = err.to_string();
-        assert!(
-            message.contains("slot_count") && message.contains("exceeds max_slots"),
-            "expected corrupt header error, got: {message}"
-        );
-    }
+    // The previous `test_reconfigure_resets_slots_to_unwritten_nan` and
+    // `test_reconfigure_rejects_corrupt_slot_count` tests exercised the
+    // legacy in-place `reconfigure_existing` path that Step 3 PR 2
+    // replaced with `ShmHandle::rebuild_via_swap`. The atomic-swap path
+    // creates an entirely fresh file (no in-place clearing window), so
+    // the NaN-reset invariant the first test guarded is satisfied
+    // structurally by `UnifiedWriter::create`'s init loop (covered by
+    // `test_write_read` / `test_writer_create`). The corrupt-header
+    // rejection the second test guarded only applies to a code path
+    // that opens an existing file in-place; the swap path never opens
+    // the previous canonical file for writing, so the failure mode is
+    // gone with the function.
 }

--- a/services/comsrv/src/main.rs
+++ b/services/comsrv/src/main.rs
@@ -201,6 +201,18 @@ async fn main() -> VoltageResult<()> {
                 voltage_rtdb_shm::ChannelPointCounts::new()
             });
 
+        // Best-effort cleanup of orphan per-generation staging files left
+        // behind by a crashed `ShmHandle::rebuild_via_swap` in a previous
+        // run. Safe to run unconditionally: matches only
+        // `{stem}-{digits}{.ext}` files in canonical's parent dir, never
+        // the canonical file itself. Steady-state operation leaves no
+        // such files (the rename consumes the staging name atomically).
+        match voltage_rtdb_shm::core::config::cleanup_orphan_generation_files(config.path()) {
+            Ok(0) => {},
+            Ok(n) => info!("removed {n} orphan SHM generation file(s) from previous run"),
+            Err(e) => warn!("orphan SHM file cleanup failed (non-fatal): {e}"),
+        }
+
         // Create UnifiedWriter from channel points (automatic slot allocation)
         // is_shm_available checks if parent directory exists (Docker mount point)
         if is_shm_available(&config) {

--- a/services/comsrv/src/store/shm_redis_sync.rs
+++ b/services/comsrv/src/store/shm_redis_sync.rs
@@ -147,13 +147,19 @@ impl<R: Rtdb> ShmRedisSync<R> {
             return;
         }
 
-        // Reconfigure-in-progress sentinel: comsrv flips writer_generation
-        // to an odd value while it is clearing slots in reconfigure_existing.
-        // Reading slots during this window would yield all-zero garbage
-        // (the byte-fill in progress). Skip this tick and retry next
-        // iteration — the even parity returns once reconfigure completes,
-        // and the subsequent layout/content-hash change will already force
-        // a full_seq reset for the new layout.
+        // Reconfigure-in-progress sentinel (defensive).
+        //
+        // Historically, comsrv flipped `writer_generation` to an odd value
+        // while clearing slots in the legacy in-place `reconfigure_existing`
+        // path; reads during that window could yield torn data. Step 3
+        // (PR #93 + this branch) replaced that with `ShmHandle::rebuild_via_swap`
+        // — a brand-new file at a staging path, then a POSIX rename(2)
+        // atomically swaps it in. There is no in-flight-mutation window any
+        // more, and `writer_generation` always stays even.
+        //
+        // The check is kept as cheap defense-in-depth: if any future code
+        // path resurrects an in-place mutation pattern, this skip prevents
+        // Redis sync from publishing torn rows.
         if writer.generation() & 1 == 1 {
             trace!("ShmRedisSync: reconfigure in progress (odd generation), skipping tick");
             self.tick_count += 1;

--- a/services/modsrv/src/main.rs
+++ b/services/modsrv/src/main.rs
@@ -295,6 +295,98 @@ async fn main() -> Result<()> {
         });
     }
 
+    // Spawn SHM canonical-path inode watcher.
+    //
+    // Step 3 of the SHM decoupling roadmap replaces in-place
+    // reconfigure_existing with `ShmHandle::rebuild_via_swap`: comsrv
+    // creates a new SHM file at a staging path, then POSIX-renames it
+    // over the canonical path. modsrv's existing UnifiedWriter is still
+    // mmap'd to the *previous* inode (now unlinked but live in memory),
+    // so its `writer.generation()` reads stay constant — the existing
+    // dispatch-time generation-mismatch check never fires for swap-based
+    // reloads.
+    //
+    // To learn about the swap, periodically `stat(canonical_path)` and
+    // compare the inode against a cached baseline. On change, fire the
+    // existing `rebuild_trigger` Notify, which the auto-rebuild task
+    // above already handles end-to-end (open_for_actions on the new
+    // inode, swap into ShmDispatch via set_writer).
+    {
+        use std::os::unix::fs::MetadataExt;
+        const WATCH_INTERVAL: Duration = Duration::from_secs(5);
+
+        let watch_notify = state.shm_dispatch.rebuild_trigger();
+        let watch_path = shm_config.path().to_path_buf();
+        let watch_token = shutdown_token.clone();
+
+        tokio::spawn(async move {
+            // Baseline: capture initial inode (None if canonical does not
+            // yet exist — comsrv may not have created it yet). We only
+            // fire on a *change* from a known-good value to avoid a
+            // spurious rebuild during cold boot.
+            let mut last_inode = std::fs::metadata(&watch_path).ok().map(|m| m.ino());
+            if let Some(ino) = last_inode {
+                info!(
+                    "SHM inode watcher: baseline inode={} for {:?}",
+                    ino, watch_path
+                );
+            } else {
+                info!(
+                    "SHM inode watcher: canonical path {:?} not yet present; will start tracking once it appears",
+                    watch_path
+                );
+            }
+
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(WATCH_INTERVAL) => {},
+                    _ = watch_token.cancelled() => break,
+                }
+
+                let current_inode = match std::fs::metadata(&watch_path) {
+                    Ok(m) => Some(m.ino()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+                    Err(e) => {
+                        warn!(
+                            "SHM inode watcher: stat {:?} failed (non-NotFound): {}",
+                            watch_path, e
+                        );
+                        continue;
+                    },
+                };
+
+                match (last_inode, current_inode) {
+                    (Some(old), Some(new)) if old != new => {
+                        info!(
+                            "SHM inode watcher: canonical path inode changed {} → {} \
+                             (comsrv likely performed an atomic-swap reload); \
+                             triggering writer rebuild",
+                            old, new
+                        );
+                        last_inode = Some(new);
+                        watch_notify.notify_one();
+                    },
+                    (None, Some(new)) => {
+                        info!(
+                            "SHM inode watcher: canonical path now exists (inode={}); \
+                             tracking baseline",
+                            new
+                        );
+                        last_inode = Some(new);
+                    },
+                    (Some(_), None) => {
+                        warn!(
+                            "SHM inode watcher: canonical path {:?} disappeared — \
+                             comsrv may be mid-restart; keeping prior baseline",
+                            watch_path
+                        );
+                    },
+                    _ => {}, // no change
+                }
+            }
+        });
+    }
+
     // Spawn channel health refresh task: mirrors `comsrv:online` into a
     // process-local cache so the M2C control gate in execute_action() can reject
     // writes targeting offline channels without per-call Redis round-trips.


### PR DESCRIPTION
## Summary

Closes out Step 3 of the SHM decoupling roadmap. Stacks on PR #94 (which switched `ShmHandle::rebuild` to the atomic-swap path and added the modsrv inode watcher).

## What's gone

- `UnifiedWriter::reconfigure_existing` — the in-place mutation function. Two unit tests that exercised it are removed alongside; their invariants now hold by construction from `UnifiedWriter::create`'s NaN-init loop.
- `validate_reconfigurable_header` — only called by reconfigure_existing, gone with it.
- Unused `fence` import.

## What's added

- `core::config::cleanup_orphan_generation_files(canonical)` — crash-recovery for staging files left behind when `rebuild_via_swap` crashed between create and rename. Pattern-matches `{stem}-{digits}{.ext}` only; never touches the canonical file. Per-file unlink failures don't abort the scan. Two unit tests for the matching logic.
- comsrv `main.rs` calls it at startup before SHM init.

## Why the deleted tests are not regressions

`test_reconfigure_resets_slots_to_unwritten_nan` checked that the in-place path correctly reset every slot to the NaN sentinel after a layout change. The swap path doesn't reset anything — it creates a brand-new file whose `UnifiedWriter::create` init loop sets every slot to the NaN sentinel as its first action. The `test_write_read` and `test_writer_create` tests already exercise that init loop.

`test_reconfigure_rejects_corrupt_slot_count` checked that the in-place path validated the existing header before trusting it. The swap path never reads the old header for layout purposes — it just calls `create` with the new `ChannelPointCounts` and renames over the canonical. The old file's potentially-corrupt header is irrelevant to the new file's contents.

## Verification

- [x] `cargo check --workspace` passes
- [x] `cargo clippy -p voltage-rtdb-shm -p comsrv -p modsrv --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p voltage-rtdb-shm` — 94 tests pass total. Net zero test count change: 2 reconfigure tests deleted, 2 cleanup-orphan tests added.

## Step 3 status

With this PR merged, Step 3 of the SHM decoupling roadmap is complete:

```
✅ per-generation file mechanism (helpers, swap method, integration test)  — PR #93
✅ ShmHandle::rebuild routes through swap + modsrv inode watcher          — PR #94
✅ Remove reconfigure_existing + crash-recovery cleanup                    — this PR
```