### PR TITLE
fix(ci): correct monarch export command syntax

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -228,17 +228,18 @@ jobs:
           echo "Checking configuration status..."
           monarch status --detailed --config-path $TEST_CONFIG_DIR --db-path $TEST_DB_DIR
 
-      # Optional: Test export functionality
+      # Test export functionality (round-trip from SQLite -> YAML/CSV)
       - name: Test Configuration Export
         run: |
           echo "Testing export functionality..."
           export EXPORT_DIR="/tmp/monarch_export_test"
           mkdir -p $EXPORT_DIR
 
-          # Try to export (this tests round-trip capability)
-          monarch export all --config-path $EXPORT_DIR --db-path $TEST_DB_DIR || {
-            echo "::warning::Export test failed, but this is optional"
-          }
+          # Export from the synced DB into a fresh output directory.
+          # `monarch export` only needs --output and --db-path; there is no
+          # `all` subcommand. This step now fails CI on real export errors
+          # rather than hiding them behind a soft warning.
+          monarch export --output $EXPORT_DIR --db-path $TEST_DB_DIR
 
           # Clean up export test
           rm -rf $EXPORT_DIR


### PR DESCRIPTION
## Summary

CI 脚本 `Test Configuration Export` step 使用了一个不存在的命令 `monarch export all`，因为该步骤设计为 `|| { echo '::warning::...' }` 软失败，所以问题被掩盖了很久。

## 原因

`monarch export` 的真实接口是：
```
monarch export [--output <DIR>] [--detailed]
```

没有 `all` 子命令；`--config-path/--db-path` 是全局参数。CI 写成 `monarch export all --config-path ...` 在 clap 解析阶段就报错。

## 变更

1. 命令修为 `monarch export --output $EXPORT_DIR --db-path $TEST_DB_DIR`（语法正确）
2. 去掉 `|| { echo "::warning::..." }`，让 export 失败硬挂 CI（符合"严禁为了通过 CI 而作假"）

## 本地验证

```
$ monarch init && monarch sync && monarch export --output /tmp/x --db-path /tmp/db
- Exporting global... global: 1 files, 15 records
- Exporting comsrv... comsrv: 27 files, 4208 records
- Exporting modsrv... modsrv: 4 files, 21 records
DONE Export completed
```

Round-trip 完全工作（同时验证了 #96 里 exporter.rs 从 `instance_properties` 表读的修复）。

## Test plan

- [x] 本地 init+sync+export 跑通
- [ ] CI Configuration Validation 通过且不再有 "Export test failed" warning